### PR TITLE
CnabParser got wrong results if some decimal value is between 0.01 and 0.09

### DIFF
--- a/boletos/bancos/common.py
+++ b/boletos/bancos/common.py
@@ -6,7 +6,7 @@ import sys
 
 
 DATE_PARSE_FORMAT = '%d%m%y'
-CURRENCY_PARSE_FORMAT = '%d.%d'
+CURRENCY_PARSE_FORMAT = '%d.%.2d'
 
 def _parse_date(s):
     try:


### PR DESCRIPTION
If some decimal value have a decimal part from 0.01 to 0.09, the parser was trimming a zero, resulting in 0.10 to 0.90 values

Does not affect decimal values bigger than 0.09, as 0.19 or 0.10
